### PR TITLE
fix(whitespace): remove leading line-break from input

### DIFF
--- a/undent.go
+++ b/undent.go
@@ -11,6 +11,10 @@ var matcher = regexp.MustCompile(`(?m)^([ \t]*)(?:\S)`)
 
 // Bytes removes leading indentation/white-space from given byte slice.
 func Bytes(b []byte) []byte {
+	if len(b) > 0 && b[0] == '\n' {
+		b = b[1:]
+	}
+
 	matches := matcher.FindAll(b, -1)
 	if len(matches) == 0 {
 		return b
@@ -39,6 +43,10 @@ func Bytes(b []byte) []byte {
 
 // String removes leading indentation/white-space from given string.
 func String(s string) string {
+	if len(s) > 0 && s[0] == '\n' {
+		s = s[1:]
+	}
+
 	matches := matcher.FindAllString(s, -1)
 	if len(matches) == 0 {
 		return s

--- a/undent_example_test.go
+++ b/undent_example_test.go
@@ -15,7 +15,6 @@ func ExampleBytes() {
 
 	fmt.Println(string(b))
 	// Output:
-	//
 	// {
 	//   "hello": "world"
 	// }
@@ -29,7 +28,6 @@ func ExampleString() {
 	)
 	fmt.Println(s)
 	// Output:
-	//
 	// {
 	//   "hello": "world"
 	// }
@@ -44,7 +42,6 @@ func ExampleStringf() {
 	)
 	fmt.Println(s)
 	// Output:
-	//
 	// {
 	//   "hello": "world"
 	// }

--- a/undent_test.go
+++ b/undent_test.go
@@ -35,8 +35,7 @@ var stringTestCases = []struct {
     "bar"
   ]
 }`,
-		want: `
-{
+		want: `{
   "hello": "world",
   "foo": [
     "bar"
@@ -52,7 +51,26 @@ var stringTestCases = []struct {
                 "bar"
               ]
             }`,
+		want: `{
+  "hello": "world",
+  "foo": [
+    "bar"
+  ]
+}`,
+	},
+	{
+		name: "multi-line space indented with leading line-breaks",
+		s: `
+
+
+            {
+              "hello": "world",
+              "foo": [
+                "bar"
+              ]
+            }`,
 		want: `
+
 {
   "hello": "world",
   "foo": [
@@ -69,7 +87,26 @@ var stringTestCases = []struct {
 					"bar"
 				]
 			}`,
+		want: `{
+	"hello": "world",
+	"foo": [
+		"bar"
+	]
+}`,
+	},
+	{
+		name: "multi-line tab indented with leading line breaks",
+		s: `
+
+
+			{
+				"hello": "world",
+				"foo": [
+					"bar"
+				]
+			}`,
 		want: `
+
 {
 	"hello": "world",
 	"foo": [
@@ -86,8 +123,7 @@ var stringTestCases = []struct {
 				"bar"
 			  ]
 			}`,
-		want: `
-{
+		want: `{
   "hello": "world",
   "foo": [
 	"bar"
@@ -105,8 +141,7 @@ var stringTestCases = []struct {
 
               ]
             }`,
-		want: `
-{
+		want: `{
   "hello": "world",
   "foo": [
 
@@ -126,8 +161,7 @@ var stringTestCases = []struct {
 
 				]
 			}`,
-		want: `
-{
+		want: `{
 	"hello": "world",
 	"foo": [
 
@@ -143,8 +177,7 @@ var stringTestCases = []struct {
             world
               foo
                 bar`,
-		want: `
-  hello
+		want: `  hello
 world
   foo
     bar`,
@@ -156,8 +189,7 @@ world
 			world
 				foo
 					bar`,
-		want: `
-	hello
+		want: `	hello
 world
 	foo
 		bar`,
@@ -197,8 +229,7 @@ var stringfTestCases = []struct {
   ]
 }`,
 		a: []interface{}{"world", 42},
-		want: `
-{
+		want: `{
   "hello": "world",
   "foo": [
     42
@@ -215,7 +246,27 @@ var stringfTestCases = []struct {
               ]
             }`,
 		a: []interface{}{"world", 42},
+		want: `{
+  "hello": "world",
+  "foo": [
+    42
+  ]
+}`,
+	},
+	{
+		name: "multi-line space indented with leading line-breaks",
+		s: `
+
+
+            {
+              "hello": "%s",
+              "foo": [
+                %d
+              ]
+            }`,
+		a: []interface{}{"world", 42},
 		want: `
+
 {
   "hello": "world",
   "foo": [
@@ -233,7 +284,27 @@ var stringfTestCases = []struct {
 				]
 			}`,
 		a: []interface{}{"world", 42},
+		want: `{
+	"hello": "world",
+	"foo": [
+		42
+	]
+}`,
+	},
+	{
+		name: "multi-line tab indented with leading line-breaks",
+		s: `
+
+
+			{
+				"hello": "%s",
+				"foo": [
+					%d
+				]
+			}`,
+		a: []interface{}{"world", 42},
 		want: `
+
 {
 	"hello": "world",
 	"foo": [
@@ -251,8 +322,7 @@ var stringfTestCases = []struct {
 			  ]
 			}`,
 		a: []interface{}{"world", 42},
-		want: `
-{
+		want: `{
   "hello": "world",
   "foo": [
 	42
@@ -271,8 +341,7 @@ var stringfTestCases = []struct {
               ]
             }`,
 		a: []interface{}{"world", 42},
-		want: `
-{
+		want: `{
   "hello": "world",
   "foo": [
 
@@ -293,8 +362,7 @@ var stringfTestCases = []struct {
 				]
 			}`,
 		a: []interface{}{"world", 42},
-		want: `
-{
+		want: `{
 	"hello": "world",
 	"foo": [
 
@@ -311,8 +379,7 @@ var stringfTestCases = []struct {
               foo
                 %d`,
 		a: []interface{}{"world", 42},
-		want: `
-  hello
+		want: `  hello
 world
   foo
     42`,
@@ -325,8 +392,7 @@ world
 				foo
 					%d`,
 		a: []interface{}{"world", 42},
-		want: `
-	hello
+		want: `	hello
 world
 	foo
 		42`,


### PR DESCRIPTION
This effectively cleans up what I consider syntactical sugar required due to
Go's syntax. For example:

    str := undent.String(`
        hello
        world`,
    )

In the above example I would consider the initial line-break after the opening
back-tick (`) character syntactical sugar, and hence should be discarded from
the final undented string.

However if the literal string contains more than one initial line-break, only
the first one should be removed, as the rest would intentionally be part of the
input.