### PR TITLE
fix(bytes): change Bytes function to accept string input but return a byte slice

### DIFF
--- a/undent.go
+++ b/undent.go
@@ -9,36 +9,17 @@ import (
 
 var matcher = regexp.MustCompile(`(?m)^([ \t]*)(?:\S)`)
 
-// Bytes removes leading indentation/white-space from given byte slice.
-func Bytes(b []byte) []byte {
-	if len(b) > 0 && b[0] == '\n' {
-		b = b[1:]
-	}
+// Bytes removes leading indentation/white-space from given string and returns
+// it as a byte slice.
+func Bytes(s string) []byte {
+	return []byte(String(s))
+}
 
-	matches := matcher.FindAll(b, -1)
-	if len(matches) == 0 {
-		return b
-	}
-
-	index := 0
-	length := len(matches[0])
-
-	for i, s := range matches[1:] {
-		l := len(s)
-		if l < length {
-			index = i + 1
-			length = l
-		}
-	}
-
-	if length <= 1 {
-		return b
-	}
-	indent := matches[index][0 : length-1]
-
-	return regexp.MustCompile(
-		`(?m)^`+regexp.QuoteMeta(string(indent)),
-	).ReplaceAllLiteral(b, []byte{})
+// Bytesf removes leading indentation/white-space from given format string
+// before passing format and all additional arguments to fmt.Sprintf, returning
+// the result as a byte slice.
+func Bytesf(format string, a ...interface{}) []byte {
+	return []byte(Stringf(format, a...))
 }
 
 // String removes leading indentation/white-space from given string.

--- a/undent_example_test.go
+++ b/undent_example_test.go
@@ -7,13 +7,27 @@ import (
 )
 
 func ExampleBytes() {
-	b := undent.Bytes([]byte(`
+	b := undent.Bytes(`
 		{
 		  "hello": "world"
 		}`,
-	))
+	)
 
 	fmt.Println(string(b))
+	// Output:
+	// {
+	//   "hello": "world"
+	// }
+}
+
+func ExampleBytesf() {
+	s := undent.Bytesf(`
+		{
+		  "hello": "%s"
+		}`,
+		"world",
+	)
+	fmt.Println(string(s))
 	// Output:
 	// {
 	//   "hello": "world"

--- a/undent_test.go
+++ b/undent_test.go
@@ -402,9 +402,21 @@ world
 func TestBytes(t *testing.T) {
 	for _, tt := range stringTestCases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := Bytes([]byte(tt.s))
+			got := Bytes(tt.s)
 
-			assert.Equal(t, []byte(tt.want), got)
+			assert.IsType(t, []byte{}, got)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestBytesf(t *testing.T) {
+	for _, tt := range stringfTestCases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Bytesf(tt.s, tt.a...)
+
+			assert.IsType(t, []byte{}, got)
+			assert.Equal(t, tt.want, string(got))
 		})
 	}
 }
@@ -414,6 +426,7 @@ func TestString(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := String(tt.s)
 
+			assert.IsType(t, "", got)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -424,6 +437,7 @@ func TestStringf(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Stringf(tt.s, tt.a...)
 
+			assert.IsType(t, "", got)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -432,10 +446,8 @@ func TestStringf(t *testing.T) {
 func BenchmarkBytes(b *testing.B) {
 	for _, tt := range stringTestCases {
 		b.Run(tt.name, func(b *testing.B) {
-			input := []byte(tt.s)
-
 			for i := 0; i < b.N; i++ {
-				Bytes(input)
+				Bytes(tt.s)
 			}
 		})
 	}


### PR DESCRIPTION
The old method signature was just nonsensical, as you would always be providing
indented values via a string literal. So it makes much more sense to have all
methods accept a string argument, and then return different types.

This also allows use of a `Bytesf` method.

This is technically a breaking change, but I'm classifying it as a bugfix cause
the old method signature was basically useless.